### PR TITLE
2.0 add browser sync

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,7 +5,6 @@ var imagemin    = require('gulp-imagemin');
 var newer       = require('gulp-newer');
 var webserver   = require('gulp-webserver');
 var uglify      = require('gulp-uglify');
-var livereload  = require('gulp-livereload');
 var sourcemaps  = require('gulp-sourcemaps');
 var browserSync = require('browser-sync').create();
 
@@ -74,7 +73,6 @@ gulp.task('server', function() {
   gulp.src('.')
     .pipe(webserver({
       open: true,
-      livereload: true
     }));
 });
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,6 +7,7 @@ var webserver   = require('gulp-webserver');
 var uglify      = require('gulp-uglify');
 var livereload  = require('gulp-livereload');
 var sourcemaps  = require('gulp-sourcemaps');
+var browserSync = require('browser-sync').create();
 
 var paths = {
   styles: {
@@ -50,7 +51,7 @@ gulp.task('sass', function (){
     ))
     .pipe(sourcemaps.write('./maps'))
     .pipe(gulp.dest(paths.styles.dest))
-    .pipe(livereload());
+    .pipe(browserSync.stream());
 });
 
 gulp.task('images', function(){
@@ -66,7 +67,7 @@ gulp.task('uglify', function() {
     .pipe(uglify())
     .pipe(sourcemaps.write('./maps'))
     .pipe(gulp.dest(paths.js.dest))
-    .pipe(livereload());
+    .pipe(browserSync.stream());
 });
 
 gulp.task('server', function() {
@@ -77,8 +78,15 @@ gulp.task('server', function() {
     }));
 });
 
-gulp.task('default', ['sass', 'uglify', 'images'], function() {
-  livereload.listen();
+gulp.task('browser-sync', function() {
+  browserSync.init({
+    server: {
+      baseDir: "./"
+    }
+  });
+});
+
+gulp.task('default', ['browser-sync', 'sass', 'uglify', 'images'], function() {
   gulp.watch(paths.styles.files,  ['sass']);
   gulp.watch(paths.js.files,      ['uglify']);
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -87,4 +87,6 @@ gulp.task('browser-sync', function() {
 gulp.task('default', ['browser-sync', 'sass', 'uglify', 'images'], function() {
   gulp.watch(paths.styles.files,  ['sass']);
   gulp.watch(paths.js.files,      ['uglify']);
+  gulp.watch("*.html").on('change', browserSync.reload);
+
 });

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "url": "https://github.com/Staplegun-US/site-start/issues"
   },
   "devDependencies": {
+    "browser-sync": "^2.10.0",
     "gulp": "3.9.0",
     "gulp-autoprefixer": "3.1.0",
     "gulp-imagemin": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "gulp": "3.9.0",
     "gulp-autoprefixer": "3.1.0",
     "gulp-imagemin": "2.4.0",
-    "gulp-livereload": "3.8.1",
     "gulp-newer": "1.0.0",
     "gulp-sass": "2.1.0",
     "gulp-sourcemaps": "^1.6.0",


### PR DESCRIPTION
Replace livereload with browser-sync. Now we don't need any plugins to get the pages reloading automatically. It's all magic. browser-sync fires when sass, js, or html is changed.

Open for review.